### PR TITLE
Prometheus updates to account for labels generated by the RPC and AWS Queue modules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 			// Automatically stop program after launch.
 			"stopOnEntry": false,
 			// Command line arguments passed to the program.
-			"args": ["-t","10000","-R","spec","-u","tdd","--recursive","./obj/test"],
+			"args": ["-t","10000","-R","spec","-u","tdd","--colors","--recursive","./obj/test"],
 			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
 			"cwd": "${workspaceRoot}",
 			//

--- a/src/count/PrometheusCounterConverter.ts
+++ b/src/count/PrometheusCounterConverter.ts
@@ -76,9 +76,28 @@ export class PrometheusCounterConverter {
         let nameParts = counter.name.split('.');
 
         // If there are other predictable names from which we can parse labels, we can add them below
-        if (nameParts.length >= 3 && nameParts[2] == "exec_time") {
+        if ((nameParts.length >= 3 && nameParts[2] == "exec_count")
+            || (nameParts.length >= 3 && nameParts[2] == "exec_time")
+            || (nameParts.length >= 3 && nameParts[2] == "exec_errors")
+        ) {
             labels["service"] = nameParts[0];
             labels["command"] = nameParts[1];
+        }
+
+        if ((nameParts.length >= 4 && nameParts[3] == "call_count")
+            || (nameParts.length >= 4 && nameParts[3] == "call_time")
+            || (nameParts.length >= 4 && nameParts[3] == "call_errors")
+        ) {
+            labels["service"] = nameParts[1];
+            labels["command"] = nameParts[2];
+            labels["target"] = nameParts[0];
+        }
+
+        if ((nameParts.length >= 3 && nameParts[2] == "sent_messages")
+            || (nameParts.length >= 3 && nameParts[2] == "received_messages")
+            || (nameParts.length >= 3 && nameParts[2] == "dead_messages")
+        ) {
+            labels["queue"] = nameParts[1];
         }
 
         if (_.isEmpty(labels)) return "";
@@ -99,8 +118,23 @@ export class PrometheusCounterConverter {
         let nameParts = counter.name.split('.');
 
         // If there are other predictable names from which we can parse labels, we can add them below
-        if (nameParts.length >= 3 && nameParts[2] == "exec_time") {
-            return nameParts[2];
+        // Rest Service Labels
+        if (nameParts.length >= 3 && nameParts[2] == "exec_count") { return nameParts[2]; }
+        if (nameParts.length >= 3 && nameParts[2] == "exec_time") { return nameParts[2]; }
+        if (nameParts.length >= 3 && nameParts[2] == "exec_errors") { return nameParts[2]; }
+
+        // Rest & Direct Client Labels
+        if (nameParts.length >= 4 && nameParts[3] == "call_count") { return nameParts[3]; }
+        if (nameParts.length >= 4 && nameParts[3] == "call_time") { return nameParts[3]; }
+        if (nameParts.length >= 4 && nameParts[3] == "call_errors") { return nameParts[3]; }
+
+        // Queue Labels
+        if ((nameParts.length >= 3 && nameParts[2] == "sent_messages")
+            || (nameParts.length >= 3 && nameParts[2] == "received_messages")
+            || (nameParts.length >= 3 && nameParts[2] == "dead_messages")
+        ) {
+            let name = `${nameParts[0]}.${nameParts[2]}`;
+            return name.toLowerCase().replace(".", "_").replace("/", "_");
         }
 
         // TODO: are there other assumptions we can make?

--- a/src/count/PrometheusCounters.ts
+++ b/src/count/PrometheusCounters.ts
@@ -147,7 +147,7 @@ export class PrometheusCounters extends CachedCounters implements IReferenceable
             let instance = this._instance || os.hostname();
             this._requestRoute = "/metrics/job/" + job + "/instance/" + instance;
 
-            let restify = require('restify');
+            let restify = require('restify-clients');
             this._client = restify.createStringClient({ url: connection.getUri() });
 
             if (callback) callback(null);

--- a/src/services/PrometheusMetricsService.ts
+++ b/src/services/PrometheusMetricsService.ts
@@ -10,14 +10,14 @@ import { PrometheusCounters } from '../count/PrometheusCounters';
 import { PrometheusCounterConverter } from '../count/PrometheusCounterConverter';
 
 /**
- * Service that exposes <code>"/metrics"</code> route for Prometheus to scap performance metrics.
+ * Service that exposes the <code>"/metrics"</code> and <code>"/metricsandreset"</code> routes for Prometheus to scap performance metrics.
  * 
  * ### Configuration parameters ###
  * 
  * - dependencies:
  *   - endpoint:              override for HTTP Endpoint dependency
  *   - prometheus-counters:   override for PrometheusCounters dependency
- * - connection(s):           
+ * - connection(s):
  *   - discovery_key:         (optional) a key to retrieve the connection from IDiscovery
  *   - protocol:              connection protocol: http or https
  *   - host:                  host name or IP address
@@ -87,6 +87,7 @@ export class PrometheusMetricsService extends RestService {
      */
     public register(): void {
         this.registerRoute("get", "metrics", null, (req, res) => { this.metrics(req, res); });
+        this.registerRoute("get", "metricsandreset", null, (req, res) => { this.metricsAndReset(req, res); });
     }
 
     /**
@@ -98,6 +99,26 @@ export class PrometheusMetricsService extends RestService {
     private metrics(req, res): void {
         let counters = this._cachedCounters != null ? this._cachedCounters.getAll() : null;
         let body = PrometheusCounterConverter.toString(counters, this._source, this._instance);
+
+        res.setHeader('content-type', 'text/plain');
+        res.statusCode = 200;
+        res.end(body);
+    }
+
+    /**
+     * Handles metricsandreset requests.
+     * The counters will be returned and then zeroed out.
+     *
+     * @param req   an HTTP request
+     * @param res   an HTTP response
+     */
+    private metricsAndReset(req, res): void {
+        let counters = this._cachedCounters != null ? this._cachedCounters.getAll() : null;
+        let body = PrometheusCounterConverter.toString(counters, this._source, this._instance);
+
+        if (this._cachedCounters != null) {
+            this._cachedCounters.clearAll();
+        }
 
         res.setHeader('content-type', 'text/plain');
         res.statusCode = 200;

--- a/src/services/PrometheusMetricsService.ts
+++ b/src/services/PrometheusMetricsService.ts
@@ -76,10 +76,13 @@ export class PrometheusMetricsService extends RestService {
 
         let contextInfo = references.getOneOptional<ContextInfo>(
             new Descriptor("pip-services", "context-info", "default", "*", "1.0"));
-        if (contextInfo != null && this._source == "")
+
+        if (contextInfo != null && (this._source == "" || this._source == undefined)) {
             this._source = contextInfo.name;
-        if (contextInfo != null && this._instance == "")
+        }
+        if (contextInfo != null && (this._instance == "" || this._instance == undefined)) {
             this._instance = contextInfo.contextId;
+        }
     }
 
     /**

--- a/test/count/PrometheusCounterConverter.test.ts
+++ b/test/count/PrometheusCounterConverter.test.ts
@@ -1,0 +1,416 @@
+import { Counter } from 'pip-services3-components-node';
+import { CounterType } from 'pip-services3-components-node';
+import { RandomDateTime } from 'pip-services3-commons-node';
+
+import { PrometheusCounterConverter } from '../../src/count/PrometheusCounterConverter';
+
+let assert = require('chai').assert;
+let async = require('async');
+
+suite('PrometheusCounterConverter', ()=> {
+
+    setup((done) => {
+        done();
+    });
+
+    teardown((done) => {
+        done();
+    });
+
+    test('KnownCounter_Exec_ServiceMetrics_Good', (done) => {
+
+        const knownCounterExecServiceMetricsGoodTestCases = [
+            { counterName: "MyService1.MyCommand1.exec_count", expectedName: "exec_count" },
+            { counterName: "MyService1.MyCommand1.exec_time", expectedName: "exec_time" },
+            { counterName: "MyService1.MyCommand1.exec_errors", expectedName: "exec_errors" }
+        ];
+
+        async.series(
+            async.each(knownCounterExecServiceMetricsGoodTestCases, function (testData, cb) {
+                const counterName = testData.counterName;
+                const expectedName = testData.expectedName;
+
+                let counters = new Array<Counter>();
+
+                let counter1 = new Counter(counterName , CounterType.Increment);
+                counter1.count = 1;
+                counter1.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter1);
+
+                let counter2 = new Counter(counterName , CounterType.Interval);
+                counter2.count = 11;
+                counter2.max = 13;
+                counter2.min = 3;
+                counter2.average = 3.5;
+                counter2.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter2);
+
+                let counter3 = new Counter(counterName , CounterType.LastValue);
+                counter3.last = 2;
+                counter3.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter3);
+
+                let counter4 = new Counter(counterName , CounterType.Statistics);
+                counter4.count = 111;
+                counter4.max = 113;
+                counter4.min = 13;
+                counter4.average = 13.5;
+                counter4.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter4);
+
+                let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+
+                let expected = `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 1\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 13\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 3\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 3.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 11\n`
+                    + `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 113\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 13\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 13.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 111\n`;
+
+                assert.equal(expected, body);
+
+                cb();
+            }),
+        done);
+    });
+
+    test('KnownCounter_Exec_ClientMetrics_Good', (done) => {
+        const knownCounterExecClientMetricsGoodTestCases = [
+            { counterName: "MyTarget1.MyService1.MyCommand1.call_count", expectedName: "call_count" },
+            { counterName: "MyTarget1.MyService1.MyCommand1.call_time", expectedName: "call_time" },
+            { counterName: "MyTarget1.MyService1.MyCommand1.call_errors", expectedName: "call_errors" }
+        ];
+
+        async.series(
+            async.each(knownCounterExecClientMetricsGoodTestCases, function (testData, cb) {
+                const counterName = testData.counterName;
+                const expectedName = testData.expectedName;
+
+                let counters = new Array<Counter>();
+
+                let counter1 = new Counter(counterName , CounterType.Increment);
+                counter1.count = 1;
+                counter1.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter1);
+
+                let counter2 = new Counter(counterName , CounterType.Interval);
+                counter2.count = 11;
+                counter2.max = 13;
+                counter2.min = 3;
+                counter2.average = 3.5;
+                counter2.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter2);
+
+                let counter3 = new Counter(counterName , CounterType.LastValue);
+                counter3.last = 2;
+                counter3.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter3);
+
+                let counter4 = new Counter(counterName , CounterType.Statistics);
+                counter4.count = 111;
+                counter4.max = 113;
+                counter4.min = 13;
+                counter4.average = 13.5;
+                counter4.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter4);
+
+                let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+
+                let expected = `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 1\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 13\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 3\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 3.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 11\n`
+                    + `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 2\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 113\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 13\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 13.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\",target=\"MyTarget1\"} 111\n`;
+
+                assert.equal(expected, body);
+
+                cb();
+            }),
+        done);
+    });
+
+    test('KnownCounter_Exec_QueueMetrics_Good', (done) => {
+        const knownCounterExecQueueMetricsGoodTestCases = [
+            { counterName: "queue.default.sent_messages", expectedName: "queue_sent_messages" },
+            { counterName: "queue.default.received_messages", expectedName: "queue_received_messages" },
+            { counterName: "queue.default.dead_messages", expectedName: "queue_dead_messages" }
+        ];
+
+        async.series(
+            async.each(knownCounterExecQueueMetricsGoodTestCases, function (testData, cb) {
+                const counterName = testData.counterName;
+                const expectedName = testData.expectedName;
+
+                let counters = new Array<Counter>();
+
+                let counter1 = new Counter(counterName , CounterType.Increment);
+                counter1.count = 1;
+                counter1.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter1);
+
+                let counter2 = new Counter(counterName , CounterType.Interval);
+                counter2.count = 11;
+                counter2.max = 13;
+                counter2.min = 3;
+                counter2.average = 3.5;
+                counter2.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter2);
+
+                let counter3 = new Counter(counterName , CounterType.LastValue);
+                counter3.last = 2;
+                counter3.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter3);
+
+                let counter4 = new Counter(counterName , CounterType.Statistics);
+                counter4.count = 111;
+                counter4.max = 113;
+                counter4.min = 13;
+                counter4.average = 13.5;
+                counter4.time = RandomDateTime.nextDateTime(new Date());
+                counters.push(counter4);
+
+                let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+
+                let expected = `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 1\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 13\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 3\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 3.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 11\n`
+                    + `# TYPE ${expectedName} gauge\n${expectedName}{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 2\n`
+                    + `# TYPE ${expectedName}_max gauge\n${expectedName}_max{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 113\n`
+                    + `# TYPE ${expectedName}_min gauge\n${expectedName}_min{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 13\n`
+                    + `# TYPE ${expectedName}_average gauge\n${expectedName}_average{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 13.5\n`
+                    + `# TYPE ${expectedName}_count gauge\n${expectedName}_count{source=\"MyApp\",instance=\"MyInstance\",queue=\"default\"} 111\n`;
+
+                assert.equal(expected, body);
+
+                cb();
+            }),
+        done);
+    });
+
+    test('EmptyCounters', (done) => {
+        let counters = new Array<Counter>();
+        let body = PrometheusCounterConverter.toString(counters, "", "");
+        assert.equal("", body);
+        done();
+    });
+
+    test('NullValues', (done) => {
+        let body = PrometheusCounterConverter.toString(null, "", "");
+        assert.equal("", body);
+        done();
+    });
+
+    test('SingleIncrement_NoLabels', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter = new Counter("MyCounter", CounterType.Increment);
+        counter.average = 2,
+        counter.min = 1,
+        counter.max = 3,
+        counter.count = 2,
+        counter.last = 3,
+        counter.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter);
+
+        let body = PrometheusCounterConverter.toString(counters, null, null);
+        const expected: string = "# TYPE mycounter gauge\nmycounter 2\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('SingleIncrement_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter = new Counter("MyCounter", CounterType.Increment);
+        counter.average = 2,
+        counter.min = 1,
+        counter.max = 3,
+        counter.count = 2,
+        counter.last = 3,
+        counter.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string = "# TYPE mycounter gauge\nmycounter{source=\"MyApp\",instance=\"MyInstance\"} 2\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiIncrement_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyCounter1", CounterType.Increment);
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyCounter2", CounterType.Increment);
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string = "# TYPE mycounter1 gauge\nmycounter1{source=\"MyApp\",instance=\"MyInstance\"} 2\n"
+                                + "# TYPE mycounter2 gauge\nmycounter2{source=\"MyApp\",instance=\"MyInstance\"} 5\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiIncrement_ExecWithOnlyTwo_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyCounter1.exec_time", CounterType.Increment);
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyCounter2.exec_time", CounterType.Increment);
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string = "# TYPE mycounter1_exec_time gauge\nmycounter1_exec_time{source=\"MyApp\",instance=\"MyInstance\"} 2\n"
+                                + "# TYPE mycounter2_exec_time gauge\nmycounter2_exec_time{source=\"MyApp\",instance=\"MyInstance\"} 5\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiIncrement_Exec_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyService1.MyCommand1.exec_time", CounterType.Increment);
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyService2.MyCommand2.exec_time", CounterType.Increment);
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string = "# TYPE exec_time gauge\nexec_time{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n"
+                                + "# TYPE exec_time gauge\nexec_time{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 5\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiInterval_Exec_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyService1.MyCommand1.exec_time", CounterType.Interval);
+        counter1.min = 1,
+        counter1.max = 3,
+        counter1.average = 2,
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyService2.MyCommand2.exec_time", CounterType.Interval);
+        counter2.min = 2,
+        counter2.max = 4,
+        counter2.average = 3,
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string =
+                "# TYPE exec_time_max gauge\nexec_time_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 3\n"
+                + "# TYPE exec_time_min gauge\nexec_time_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 1\n"
+                + "# TYPE exec_time_average gauge\nexec_time_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n"
+                + "# TYPE exec_time_count gauge\nexec_time_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n"
+                + "# TYPE exec_time_max gauge\nexec_time_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 4\n"
+                + "# TYPE exec_time_min gauge\nexec_time_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 2\n"
+                + "# TYPE exec_time_average gauge\nexec_time_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 3\n"
+                + "# TYPE exec_time_count gauge\nexec_time_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 5\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiStatistics_Exec_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyService1.MyCommand1.exec_time", CounterType.Statistics);
+        counter1.min = 1,
+        counter1.max = 3,
+        counter1.average = 2,
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyService2.MyCommand2.exec_time", CounterType.Statistics);
+        counter2.min = 2,
+        counter2.max = 4,
+        counter2.average = 3,
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string =
+            "# TYPE exec_time_max gauge\nexec_time_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 3\n"
+            + "# TYPE exec_time_min gauge\nexec_time_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 1\n"
+            + "# TYPE exec_time_average gauge\nexec_time_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n"
+            + "# TYPE exec_time_count gauge\nexec_time_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 2\n"
+            + "# TYPE exec_time_max gauge\nexec_time_max{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 4\n"
+            + "# TYPE exec_time_min gauge\nexec_time_min{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 2\n"
+            + "# TYPE exec_time_average gauge\nexec_time_average{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 3\n"
+            + "# TYPE exec_time_count gauge\nexec_time_count{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 5\n";
+        assert.equal(expected, body);
+
+        done();
+    });
+
+    test('MultiLastValue_Exec_SourceInstance', (done) => {
+        let counters = new Array<Counter>();
+
+        let counter1 = new Counter("MyService1.MyCommand1.exec_time", CounterType.LastValue);
+        counter1.count = 2,
+        counter1.last = 3,
+        counter1.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter1);
+
+        let counter2 = new Counter("MyService2.MyCommand2.exec_time", CounterType.LastValue);
+        counter2.count = 5,
+        counter2.last = 10,
+        counter2.time = RandomDateTime.nextDateTime(new Date());
+        counters.push(counter2);
+
+        let body = PrometheusCounterConverter.toString(counters, "MyApp", "MyInstance");
+        const expected: string = "# TYPE exec_time gauge\nexec_time{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService1\",command=\"MyCommand1\"} 3\n"
+                                + "# TYPE exec_time gauge\nexec_time{source=\"MyApp\",instance=\"MyInstance\",service=\"MyService2\",command=\"MyCommand2\"} 10\n";
+
+        assert.equal(expected, body);
+
+        done();
+    });
+});

--- a/test/services/PrometheusMetricsService.test.ts
+++ b/test/services/PrometheusMetricsService.test.ts
@@ -1,11 +1,12 @@
 let assert = require('chai').assert;
-let restify = require('restify');
+let restify = require('restify-clients');
 let async = require('async');
 
 import { Descriptor } from 'pip-services3-commons-node';
 import { ConfigParams } from 'pip-services3-commons-node';
 import { References } from 'pip-services3-commons-node';
 import { ContextInfo } from 'pip-services3-components-node';
+import { CounterType } from 'pip-services3-components-node';
 
 import { PrometheusMetricsService } from '../../src/services/PrometheusMetricsService';
 import { PrometheusCounters } from '../../src/count/PrometheusCounters';
@@ -16,7 +17,7 @@ var restConfig = ConfigParams.fromTuples(
     "connection.port", 3000
 );
 
-suite('PrometheusMetricsService', ()=> {
+suite('PrometheusMetricsService', () => {
     let service: PrometheusMetricsService;
     let counters: PrometheusCounters;
     let rest: any;
@@ -43,7 +44,7 @@ suite('PrometheusMetricsService', ()=> {
             service.open(null, done);
         });
     });
-    
+
     suiteTeardown((done) => {
         service.close(null, (err) => {
             counters.close(null, done);
@@ -54,7 +55,7 @@ suite('PrometheusMetricsService', ()=> {
         let url = 'http://localhost:3000';
         rest = restify.createStringClient({ url: url });
     });
-    
+
     test('Metrics', (done) => {
         counters.incrementOne('test.counter1');
         counters.stats('test.counter2', 2);
@@ -64,7 +65,7 @@ suite('PrometheusMetricsService', ()=> {
         rest.get('/metrics',
             (err, req, res, result) => {
                 assert.isNull(err);
-                
+
                 assert.isNotNull(result);
                 assert.isTrue(res.statusCode < 400);
                 assert.isTrue(result.length > 0);
@@ -74,4 +75,32 @@ suite('PrometheusMetricsService', ()=> {
         );
     });
 
+    test('MetricsAndReset', (done) => {
+        counters.incrementOne('test.counter1');
+        counters.stats('test.counter2', 2);
+        counters.last('test.counter3', 3);
+        counters.timestampNow('test.counter4');
+
+        rest.get('/metricsandreset',
+            (err, req, res, result) => {
+                assert.isNull(err);
+
+                assert.isNotNull(result);
+                assert.isTrue(res.statusCode < 400);
+                assert.isTrue(result.length > 0);
+
+                let counter1 = counters.get("test.counter1", CounterType.Increment);
+                let counter2 = counters.get("test.counter2", CounterType.Statistics);
+                let counter3 = counters.get("test.counter3", CounterType.LastValue);
+                let counter4 = counters.get("test.counter4", CounterType.Timestamp);
+
+                assert.isUndefined(counter1.count);
+                assert.isUndefined(counter2.count);
+                assert.isUndefined(counter3.last);
+                assert.isUndefined(counter4.time);
+
+                done();
+            }
+        );
+    });
 });


### PR DESCRIPTION
_*Edited for Bug fix_

**PrometheusCounterConverter Updates**

Updated the `generateCounterLabel` and `parseCounterName` methods to account for the counter updates in the RPC & AWS projects.

This includes the following counters from the RPC project

- exec_count
- exec_time
- exec_errors
- call_count
- call_time
- call_errors

And also the following counters from the AWS project

- sent_messages
- received_messages
- dead_messages

The counter labels have been updated to account for exec and call counter labels from the RPC project.
The AWS Queue counter labels have also been added.
Unit tests have been added for this change.

**PrometheusMetricsService Updates**

A new method called 'metricsandreset' has been added.
This method will reset the counters after they have been read.
Unit tests have been added for this change.

**NOTE** 
The restify package has been changed and the line `let restify = require('restify');` has been updated to `let restify = require('restify-clients');` as a result.
This was required to get the tests to pass before making any updates.

This change was made in the following files

- PrometheusCounters.ts
- PrometheusMetricsService.test.ts

**Bug Fix**

The prometheus metrics service was not setting `_source` or `_instance` in the `setReferences` method, a check for undefined has been added to fix this issue.
